### PR TITLE
feat: create mcmap.bin from BGP IPv4/IPv6 multicast channels

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -56,8 +56,10 @@ jobs:
           echo "Generating map..."
           cd generator
           chmod +x cicd_gen.sh
-          ./cicd_gen.sh
+          ./cicd_gen.sh "config.sample.json"
           cp map.bin ../pages/
+          ./cicd_gen.sh "config.mcast.sample.json"
+          cp map.bin ../pages/mcmap.bin
           cd ..
 
           echo "Placing public sources..."

--- a/generator/cicd_gen.sh
+++ b/generator/cicd_gen.sh
@@ -3,7 +3,9 @@ set -ex
 registry_path="https://${GIT_DN42_TOKEN}@git.dn42.dev/dn42/registry.git"
 [ -e dn42registry ] && (cd dn42registry; git pull) || git clone "$registry_path" dn42registry --depth 1 --single-branch
 [ -e map.bin ] && rm map.bin
+config="$1"
+[ -z "$config" ] && config="config.sample.json"
 go mod download
 go build -o mapdn42
-cp config.sample.json config.json
+cp "$config" config.json
 ./mapdn42

--- a/generator/config.mcast.sample.json
+++ b/generator/config.mcast.sample.json
@@ -1,0 +1,18 @@
+{
+    "registry_path": "./dn42registry",
+    "output_file": "./map.bin",
+    "post_generation_command": "",
+    "mrt_collector": {
+        "ipv4_mrt_dump_url": "https://mrt.iedon.net/multicast4_latest.mrt.bz2",
+        "ipv6_mrt_dump_url": "https://mrt.iedon.net/multicast6_latest.mrt.bz2",
+        "username": "CanAlsoSpecifyInEnv",
+        "password": "CanAlsoSpecifyInEnv",
+        "insecure_skip_verify": true,
+        "custom_dns_server": ""
+    },
+    "api": {
+        "enabled": false,
+        "listen_addr": ":8080",
+        "auth_token": "your-secret-token-here"
+    }
+}


### PR DESCRIPTION
This would be helpful for us to immidiately monitor the BGP peerings for the IPv4/IPv6 multicast channels thanks to the "data" HTTP GET paramater, without needing to deploy an extra instance for now.